### PR TITLE
Use HEAD response statuscode for error checks

### DIFF
--- a/pkg/registry_checker/image_pull.go
+++ b/pkg/registry_checker/image_pull.go
@@ -2,6 +2,7 @@ package registry_checker
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -15,13 +16,7 @@ func IsAbsent(err error) bool {
 		return false
 	}
 
-	for _, transportError := range transpErr.Errors {
-		if transportError.Code == transport.ManifestUnknownErrorCode {
-			return true
-		}
-	}
-
-	return false
+	return transpErr.StatusCode == http.StatusNotFound
 }
 
 func IsAuthnFail(err error) bool {
@@ -32,13 +27,7 @@ func IsAuthnFail(err error) bool {
 		return false
 	}
 
-	for _, transportError := range transpErr.Errors {
-		if transportError.Code == transport.UnauthorizedErrorCode {
-			return true
-		}
-	}
-
-	return false
+	return transpErr.StatusCode == http.StatusUnauthorized
 }
 
 func IsAuthzFail(err error) bool {
@@ -49,13 +38,7 @@ func IsAuthzFail(err error) bool {
 		return false
 	}
 
-	for _, transportError := range transpErr.Errors {
-		if transportError.Code == transport.DeniedErrorCode {
-			return true
-		}
-	}
-
-	return false
+	return transpErr.StatusCode == http.StatusForbidden
 }
 
 func IsOldRegistry(err error) bool {


### PR DESCRIPTION
After upgrading from 0.1.17 to 0.2.0 missing images are reported under the 'unknown_error' metric instead of absent==1.

Log:
```
ERRO[2021-12-06T16:23:08+01:00] HEAD https://registry.example.io/v2/my-example/manifests/my-tag: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)  availability_mode=unknown_error image_name="registry.example.io/v2/my-example/manifests/my-tag"
```
> availability_mode=**unknown_error** 

The `isAbsent` check (image_pull.go) checks the `Errors` field (https://github.com/distribution/distribution/blob/main/docs/spec/api.md#errors), after the GET -> HEAD switch this diagnostic errors field is always empty (HEAD responses have no body, use GET for details). The HEAD request will just return a 404, see https://github.com/distribution/distribution/blob/main/docs/spec/api.md#existing-manifests, so I guess checking the http statuscode is enough.

Log after change:
```
ERRO[2021-12-06T16:23:08+01:00] HEAD https://registry.example.io/v2/my-example/manifests/my-tag: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)  availability_mode=absent image_name="registry.example.io/v2/my-example/manifests/my-tag"
```
> availability_mode=**absent** 

Now the image shows up again in the `*_absent` metric with value 1