### PR TITLE
Fix ignoring all images when --ignored-images option absent

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,9 +66,11 @@ func main() {
 	prometheus.MustRegister(liveTicksCounter)
 
 	var regexes []regexp.Regexp
-	regexStrings := strings.Split(*ignoredImagesStr, "~")
-	for _, regexStr := range regexStrings {
-		regexes = append(regexes, *regexp.MustCompile(regexStr))
+	if *ignoredImagesStr != "" {
+		regexStrings := strings.Split(*ignoredImagesStr, "~")
+		for _, regexStr := range regexStrings {
+			regexes = append(regexes, *regexp.MustCompile(regexStr))
+		}
 	}
 
 	registryChecker := registry_checker.NewRegistryChecker(


### PR DESCRIPTION
Fix #55

When `--ignored-images` option absent we have regexp list with one compile regexp.
This regexp with compile empty string value matches all images in k8s cluster and exporter ignore they.

This is due to calling `string.Split()` in this piece of code:
```
var regexes []regexp.Regexp
regexStrings := strings.Split(*ignoredImagesStr, "~")
  for _, regexStr := range regexStrings {
    regexes = append(regexes, *regexp.MustCompile(regexStr))
  }
```

We should fill the `regexes` array only if the `--ignored-images` option was specified when starting the exporter.
