### PR TITLE
adding additional serviceMonitor Labels to match prometheus serviceMo…

### DIFF
--- a/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
+++ b/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ template "k8s-image-availability-exporter.fullname" . }}
   labels:
     app: {{ template "k8s-image-availability-exporter.fullname" . }}
+    {{- if .Values.serviceMonitor.additional_labels.enabled }}
+    release: {{ .Values.serviceMonitor.additional_labels.prometheus_service_monitor_selector.release }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       app: {{ template "k8s-image-availability-exporter.fullname" . }}
-      {{- if .Values.serviceMonitor.additional_labels.enabled }}
-      release: {{ .Values.serviceMonitor.additional_labels.prometheus_service_monitor_selector.release }}
-      {{- end }}
   endpoints:
   - port: http
     interval: {{ .Values.serviceMonitor.interval }}

--- a/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
+++ b/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
@@ -9,6 +9,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "k8s-image-availability-exporter.fullname" . }}
+      {{- if .Values.serviceMonitor.additional_labels.enabled }}
+      release: {{ .Values.serviceMonitor.additional_labels.prometheus_service_monitor_selector.release }}
+      {{- end }}
   endpoints:
   - port: http
     interval: {{ .Values.serviceMonitor.interval }}

--- a/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
+++ b/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ template "k8s-image-availability-exporter.fullname" . }}
     {{- if .Values.serviceMonitor.additional_labels.enabled }}
-    release: {{ .Values.serviceMonitor.additional_labels.prometheus_service_monitor_selector.release }}
+    {{- toYaml .Values.serviceMonitor.additional_labels.prometheus_service_monitor_selector | nindent 4}}
     {{- end }}
 spec:
   selector:

--- a/helm/charts/k8s-image-availability-exporter/values.yaml
+++ b/helm/charts/k8s-image-availability-exporter/values.yaml
@@ -11,6 +11,10 @@ k8sImageAvailabilityExporter:
 serviceMonitor:
   enabled: false
   interval: 15s
+  additional_labels: 
+    enabled: false
+    prometheus_service_monitor_selector: 
+      release: "serviceMonitorSelector_for_Prometheus"
 
 prometheusRule:
   enabled: false


### PR DESCRIPTION
Adding additional labels in order to have flexability to add serviceMonitorSelector Lable which is used in prometheus server, instead of deploying the exporter then having to label the service monitor with an extra label in order for prometheus to detect/discover k8s-image-exporter serviceMonitor. 