### PR TITLE
Migrate CronJob to the api-version batch/v1

### DIFF
--- a/pkg/registry_checker/checker.go
+++ b/pkg/registry_checker/checker.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
-	"k8s.io/client-go/informers/batch/v1beta1"
+	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 
 	"k8s.io/client-go/informers"
@@ -46,7 +46,7 @@ type RegistryChecker struct {
 	deploymentsInformer    appsv1informers.DeploymentInformer
 	statefulSetsInformer   appsv1informers.StatefulSetInformer
 	daemonSetsInformer     appsv1informers.DaemonSetInformer
-	cronJobsInformer       v1beta1.CronJobInformer
+	cronJobsInformer       batchv1informers.CronJobInformer
 	secretsInformer        corev1informers.SecretInformer
 
 	controllerIndexers ControllerIndexers
@@ -82,7 +82,7 @@ func NewRegistryChecker(
 		deploymentsInformer:    informerFactory.Apps().V1().Deployments(),
 		statefulSetsInformer:   informerFactory.Apps().V1().StatefulSets(),
 		daemonSetsInformer:     informerFactory.Apps().V1().DaemonSets(),
-		cronJobsInformer:       informerFactory.Batch().V1beta1().CronJobs(),
+		cronJobsInformer:       informerFactory.Batch().V1().CronJobs(),
 		secretsInformer:        informerFactory.Core().V1().Secrets(),
 
 		ignoredImagesRegex: ignoredImages,

--- a/pkg/registry_checker/indexers.go
+++ b/pkg/registry_checker/indexers.go
@@ -9,7 +9,7 @@ import (
 	kubeauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -146,7 +146,7 @@ func getImagesFromCronJob(obj interface{}) (interface{}, error) {
 		return cis, nil
 	}
 
-	cronJob := obj.(*batchv1beta.CronJob)
+	cronJob := obj.(*batchv1.CronJob)
 
 	cronJobCopy := cronJob.DeepCopy()
 


### PR DESCRIPTION
Batch/v1 api is available from the kubernetes 1.21. So, we can use it as default.
While batch/v1beta1 is not available in the kubernetes 1.25+