### PR TITLE
Add support for additional labels to ServiceMonitor

### DIFF
--- a/helm/charts/k8s-image-availability-exporter/Chart.yaml
+++ b/helm/charts/k8s-image-availability-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.5.1"
 description: Application for monitoring the cluster workloads image presence in docker registry.
 name: k8s-image-availability-exporter
-version: "0.5.1"
+version: "0.5.2"

--- a/helm/charts/k8s-image-availability-exporter/README.md
+++ b/helm/charts/k8s-image-availability-exporter/README.md
@@ -45,6 +45,7 @@ The following tables list the configurable parameters of the k8s-image-availabil
 | `k8sImageAvailabilityExporter.replicas` | Number of instances to deploy for a k8s-image-availability-exporter deployment. | `1` |
 | `k8sImageAvailabilityExporter.resources` | Resource limits for k8s-image-availability-exporter | `{}` |
 | `serviceMonitor.enabled` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) serviceMonitor resource | `false` |
+| `serviceMonitor.additionalLabels` | Additional labels used by the Prometheus to select Service Monitors | `{}` |
 | `serviceMonitor.interval` | Scrape interval for serviceMonitor | `15s` |
 | `prometheusRule.enabled` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) prometheusRule resource | `false` |
 | `prometheusRule.defaultGroupsEnabled` | Setup default alerts (works only if prometheusRule.enabled is set to true) | `true` |

--- a/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
+++ b/helm/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "k8s-image-availability-exporter.fullname" . }}
   labels:
     app: {{ template "k8s-image-availability-exporter.fullname" . }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/charts/k8s-image-availability-exporter/values.yaml
+++ b/helm/charts/k8s-image-availability-exporter/values.yaml
@@ -7,9 +7,10 @@ k8sImageAvailabilityExporter:
   resources: {}
   args:
     - --bind-address=:8080
-  
+
 serviceMonitor:
   enabled: false
+  additionalLabels: {}
   interval: 15s
 
 prometheusRule:


### PR DESCRIPTION
This PR dups #58 but uses camel case formatting and preserves default chart behaviour.

## Added

- Support for extra labels in ServiceMonitor resource.