### PR TITLE
Add option to force image check for disabled/suspended workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ docker pull registry.deckhouse.io/k8s-image-availability-exporter/k8s-image-avai
 The helm chart is available on [artifacthub](https://artifacthub.io/packages/helm/k8s-image-availability-exporter/k8s-image-availability-exporter). Follow instructions on the page to install it.
 
 ### Prometheus integration
- 
+
 Here's how you can configure Prometheus or prometheus-operator to scrape metrics from `k8s-image-availability-exporter`.
- 
+
 #### Prometheus
 
 ```yaml
@@ -161,7 +161,7 @@ spec:
           in Deployment `{{ $labels.owner_name }}`
           in container `{{ $labels.container }}` in registry.
         summary: Image `{{ $labels.image }}` is unavailable.
-    
+
     - alert: StatefulSetImageUnavailable
       expr: |
         max by (namespace, statefulset, container, image) (
@@ -174,7 +174,7 @@ spec:
           in StatefulSet `{{ $labels.owner_name }}`
           in container `{{ $labels.container }}` in registry.
         summary: Image `{{ $labels.image }}` is unavailable in container registry.
-    
+
     - alert: DaemonSetImageUnavailable
       expr: |
         max by (namespace, daemonset, container, image) (
@@ -187,7 +187,7 @@ spec:
           in DaemonSet `{{ $labels.owner_name }}`
           in container `{{ $labels.container }}` in registry.
         summary: Image `{{ $labels.image }}` is unavailable in container registry.
-    
+
     - alert: CronJobImageUnavailable
       expr: |
         max by (namespace, cronjob, container, image) (
@@ -218,6 +218,8 @@ Usage of k8s-image-availability-exporter:
         image re-check interval (default 1m0s)
   -default-registry string
         default registry to use in absence of a fully qualified image name, defaults to "index.docker.io"
+  -force-check-disabled-controllers value
+        comma-separated list of controller kinds for which image is forcibly checked, even when workloads are disabled or suspended. Acceptable values include "Deployment", "StatefulSet", "DaemonSet", "Cronjob" or "*" for all kinds (this option is case-insensitive)
   -ignored-images string
         tilde-separated image regexes to ignore, each image will be checked against this list of regexes
   -namespace-label string
@@ -243,7 +245,7 @@ Each `<TYPE>` in the exporter's metrics name is replaced with the following valu
 
 * `deployment`
 * `statefulset`
-* `daemonset` 
+* `daemonset`
 * `cronjob`
 
 ## Compatibility

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"slices"
 	"strings"
 	"time"
 
+	"github.com/flant/k8s-image-availability-exporter/pkg/cli"
 	"github.com/flant/k8s-image-availability-exporter/pkg/handlers"
 	"github.com/flant/k8s-image-availability-exporter/pkg/logging"
 	"github.com/flant/k8s-image-availability-exporter/pkg/registry"
@@ -39,32 +39,8 @@ func main() {
 	defaultRegistry := flag.String("default-registry", "", fmt.Sprintf("default registry to use in absence of a fully qualified image name, defaults to %q", name.DefaultRegistry))
 	flag.Var(cp, "capath", "path to a file that contains CA certificates in the PEM format") // named after the curl cli flag
 
-	var forceCheckDisabledControllerKinds []string
-	flag.Func("force-check-disabled-controllers", `comma-separated list of controller kinds for which image is forcibly checked, even when workloads are disabled or suspended. Acceptable values include "Deployment", "StatefulSet", "DaemonSet", "Cronjob" or "*" for all kinds (this option is case-insensitive)`, func(flagValue string) error {
-		allowedControllerKinds := []string{"deployment", "statefulset", "daemonset", "cronjob"}
-
-	flagLoop:
-		for _, kind := range strings.Split(flagValue, ",") {
-			kind = strings.ToLower(kind)
-			if kind == "*" {
-				forceCheckDisabledControllerKinds = allowedControllerKinds
-				return nil
-			}
-
-			for _, allowedControllerKind := range allowedControllerKinds {
-				if kind == allowedControllerKind {
-					if !slices.Contains(forceCheckDisabledControllerKinds, kind) {
-						forceCheckDisabledControllerKinds = append(forceCheckDisabledControllerKinds, kind)
-					}
-					continue flagLoop
-				}
-			}
-
-			return fmt.Errorf(`must be one of %s or * for all kinds`, strings.Join(allowedControllerKinds, ", "))
-		}
-
-		return nil
-	})
+	forceCheckDisabledControllerKindsParser := cli.NewForceCheckDisabledControllerKindsParser()
+	flag.Func("force-check-disabled-controllers", `comma-separated list of controller kinds for which image is forcibly checked, even when workloads are disabled or suspended. Acceptable values include "Deployment", "StatefulSet", "DaemonSet", "Cronjob" or "*" for all kinds (this option is case-insensitive)`, forceCheckDisabledControllerKindsParser.Parse)
 
 	flag.Parse()
 
@@ -109,7 +85,7 @@ func main() {
 		*insecureSkipVerify,
 		*plainHTTP,
 		*cp,
-		forceCheckDisabledControllerKinds,
+		forceCheckDisabledControllerKindsParser.ParsedKinds,
 		regexes,
 		*defaultRegistry,
 		*namespaceLabels,

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type ForceCheckDisabledControllerKindsParser struct {
+	allowedControllerKinds []string
+	ParsedKinds            []string
+}
+
+func (parser *ForceCheckDisabledControllerKindsParser) Parse(flagValue string) error {
+	if flagValue == "*" {
+		parser.ParsedKinds = parser.allowedControllerKinds
+		return nil
+	}
+
+	parser.ParsedKinds = []string{}
+
+flagLoop:
+	for _, kind := range strings.Split(flagValue, ",") {
+		kind = strings.ToLower(kind)
+
+		for _, allowedControllerKind := range parser.allowedControllerKinds {
+			if kind == allowedControllerKind {
+				if !slices.Contains(parser.ParsedKinds, kind) {
+					parser.ParsedKinds = append(parser.ParsedKinds, kind)
+				}
+				continue flagLoop
+			}
+		}
+
+		return fmt.Errorf(`must be one of %s or * for all kinds`, strings.Join(parser.allowedControllerKinds, ", "))
+	}
+
+	return nil
+}
+
+func NewForceCheckDisabledControllerKindsParser() *ForceCheckDisabledControllerKindsParser {
+	parser := &ForceCheckDisabledControllerKindsParser{}
+	parser.allowedControllerKinds = []string{"deployment", "statefulset", "daemonset", "cronjob"}
+	return parser
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ForceCheckDisabledControllerKindsParser(t *testing.T) {
+	const (
+		allKinds                = "*"
+		goodKinds               = "deployment,statefulset"
+		goodKindsWithDuplicates = "deployment,deployment,statefulset,cronjob,cronjob"
+		goodKindsWithWildcard   = "deployment,statefulset,*"
+		badKinds                = "deployment,job"
+	)
+	parser := NewForceCheckDisabledControllerKindsParser()
+	expectedErr := fmt.Errorf(`must be one of %s or * for all kinds`, strings.Join(parser.allowedControllerKinds, ", "))
+
+	err := parser.Parse(allKinds)
+	require.NoError(t, err)
+	require.Equal(t, parser.ParsedKinds, parser.allowedControllerKinds)
+
+	err = parser.Parse(goodKinds)
+	require.NoError(t, err)
+	require.Equal(t, parser.ParsedKinds, []string{"deployment", "statefulset"})
+
+	err = parser.Parse(goodKindsWithDuplicates)
+	require.NoError(t, err)
+	require.Equal(t, parser.ParsedKinds, []string{"deployment", "statefulset", "cronjob"})
+
+	err = parser.Parse(goodKindsWithWildcard)
+	require.Error(t, expectedErr, err)
+
+	err = parser.Parse(badKinds)
+	require.Error(t, expectedErr, err)
+}

--- a/pkg/registry/checker.go
+++ b/pkg/registry/checker.go
@@ -68,6 +68,7 @@ func NewChecker(
 	skipVerify bool,
 	plainHTTP bool,
 	caPths []string,
+	forceCheckDisabledControllerKinds []string,
 	ignoredImages []regexp.Regexp,
 	defaultRegistry string,
 	namespaceLabel string,
@@ -206,6 +207,8 @@ func NewChecker(
 	rc.controllerIndexers.cronJobIndexer = rc.cronJobsInformer.Informer().GetIndexer()
 
 	rc.controllerIndexers.secretIndexer = rc.secretsInformer.Informer().GetIndexer()
+
+	rc.controllerIndexers.forceCheckDisabledControllerKinds = forceCheckDisabledControllerKinds
 
 	go informerFactory.Start(stopCh)
 	logrus.Info("Waiting for cache sync")

--- a/pkg/registry/indexers.go
+++ b/pkg/registry/indexers.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/flant/k8s-image-availability-exporter/pkg/store"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -21,13 +23,14 @@ const (
 )
 
 type ControllerIndexers struct {
-	namespaceIndexer      cache.Indexer
-	serviceAccountIndexer cache.Indexer
-	deploymentIndexer     cache.Indexer
-	statefulSetIndexer    cache.Indexer
-	daemonSetIndexer      cache.Indexer
-	cronJobIndexer        cache.Indexer
-	secretIndexer         cache.Indexer
+	namespaceIndexer                  cache.Indexer
+	serviceAccountIndexer             cache.Indexer
+	deploymentIndexer                 cache.Indexer
+	statefulSetIndexer                cache.Indexer
+	daemonSetIndexer                  cache.Indexer
+	cronJobIndexer                    cache.Indexer
+	secretIndexer                     cache.Indexer
+	forceCheckDisabledControllerKinds []string
 }
 
 type controllerWithContainerInfos struct {
@@ -51,7 +54,7 @@ var (
 )
 
 func (ci ControllerIndexers) validCi(cis *controllerWithContainerInfos) bool {
-	if !cis.enabled {
+	if !cis.enabled && !slices.Contains(ci.forceCheckDisabledControllerKinds, strings.ToLower(cis.controllerKind)) {
 		return false
 	}
 


### PR DESCRIPTION
Currently the exporter does not check the availability of docker image for disable/suspend workloads. I add a CLI option `check-disabled` that will bypass the workload `enable` status check. This force docker image check for disabled/suspended workloads.

Option `check-disabled` equal `false` by default to avoid creating breaking changes.

Closes #74 