### PR TITLE
Add placement options for the exporter to the chart

### DIFF
--- a/charts/k8s-image-availability-exporter/Chart.yaml
+++ b/charts/k8s-image-availability-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "v0.5.1"
 description: Application for monitoring the cluster workloads image presence in a container registry.
 name: k8s-image-availability-exporter
-version: "0.7.0"
+version: "0.8.0"
 kubeVersion: ">=1.14.0-0"

--- a/charts/k8s-image-availability-exporter/README.md
+++ b/charts/k8s-image-availability-exporter/README.md
@@ -1,6 +1,6 @@
 # k8s-image-availability-exporter
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
 
 Application for monitoring the cluster workloads image presence in a container registry.
 
@@ -19,16 +19,26 @@ This chart bootstraps a [k8s-image-availability-exporter](https://github.com/fla
 | k8sImageAvailabilityExporter.image.repository | string | `"registry.deckhouse.io/k8s-image-availability-exporter/k8s-image-availability-exporter"` | Repository to use for the k8s-image-availability-exporter deployment |
 | k8sImageAvailabilityExporter.image.tag | string | `""` | Image tag override for the default value (chart appVersion) |
 | k8sImageAvailabilityExporter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for the k8s-image-availability-exporter deployment |
-| k8sImageAvailabilityExporter.replicas | int | `1` | Number of instances to deploy for a k8s-image-availability-exporter deployment |
-| k8sImageAvailabilityExporter.resources | object | `{}` | Resource limits for k8s-image-availability-exporter |
 | k8sImageAvailabilityExporter.args | list | `["--bind-address=:8080"]` | Command line arguments for the exporter |
+| replicaCount | int | `1` | Number of replicas (pods) to launch. |
+| podSecurityContext | object | `{}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
+| securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
+| nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |
+| tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
+| affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
+| topologySpreadConstraints | list | `[]` | [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
+| strategy | object | `{}` | Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration. |
+| revisionHistoryLimit | int | `10` | Define the [count of deployment revisions](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) to be kept. May be set to 0 in case of GitOps deployment approach. |
+| podDisruptionBudget.enabled | bool | `false` | Enable a [pod distruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to help dealing with [disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). It is **highly recommended** for webhooks as disruptions can prevent launching new pods. |
+| podDisruptionBudget.minAvailable | int/percentage | `nil` | Number or percentage of pods that must remain available. |
+| podDisruptionBudget.maxUnavailable | int/percentage | `nil` | Number or percentage of pods that can be unavailable. |
+| priorityClassName | string | `""` | Specify a priority class name to set [pod priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority). |
+| resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | serviceMonitor.enabled | bool | `false` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) serviceMonitor resource |
 | serviceMonitor.interval | string | `"15s"` | Scrape interval for serviceMonitor |
 | prometheusRule.enabled | bool | `false` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) prometheusRule resource |
 | prometheusRule.defaultGroupsEnabled | bool | `true` | Setup default alerts (works only if prometheusRule.enabled is set to true) |
 | prometheusRule.additionalGroups | list | `[]` | Additional PrometheusRule groups |
-| podSecurityContext | object | `{}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
-| securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/k8s-image-availability-exporter/templates/deployment.yaml
+++ b/charts/k8s-image-availability-exporter/templates/deployment.yaml
@@ -10,7 +10,12 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/component: monitoring
 spec:
-  replicas: {{ .Values.k8sImageAvailabilityExporter.replicas }}
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "k8s-image-availability-exporter.fullname" . }}
@@ -19,6 +24,9 @@ spec:
       labels:
         app: {{ template "k8s-image-availability-exporter.fullname" . }}
     spec:
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       containers:
       - name: k8s-image-availability-exporter
         {{- if .Values.k8sImageAvailabilityExporter.args }}
@@ -52,9 +60,23 @@ spec:
             port: http
             scheme: HTTP
         resources:
-        {{ if .Values.k8sImageAvailabilityExporter.resources }}
-{{ .Values.k8sImageAvailabilityExporter.resources | toYaml | indent 10}}
-        {{ end }}
+          {{- toYaml .Values.resources | nindent 12 }}
       serviceAccountName: {{ template "k8s-image-availability-exporter.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/k8s-image-availability-exporter/templates/poddisruptionbudget.yaml
+++ b/charts/k8s-image-availability-exporter/templates/poddisruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+  labels:
+    app: {{ template "k8s-image-availability-exporter.fullname" . }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "k8s-image-availability-exporter.fullname" . }}
+{{- end }}

--- a/charts/k8s-image-availability-exporter/values.yaml
+++ b/charts/k8s-image-availability-exporter/values.yaml
@@ -6,27 +6,12 @@ k8sImageAvailabilityExporter:
     tag: ""
     # -- Image pull policy to use for the k8s-image-availability-exporter deployment
     pullPolicy: IfNotPresent
-  # -- Number of instances to deploy for a k8s-image-availability-exporter deployment
-  replicas: 1
-  # -- Resource limits for k8s-image-availability-exporter
-  resources: {}
   # -- Command line arguments for the exporter
   args:
     - --bind-address=:8080
 
-serviceMonitor:
-  # -- Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) serviceMonitor resource
-  enabled: false
-  # -- Scrape interval for serviceMonitor
-  interval: 15s
-
-prometheusRule:
-  # -- Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) prometheusRule resource
-  enabled: false
-  # -- Setup default alerts (works only if prometheusRule.enabled is set to true)
-  defaultGroupsEnabled: true
-  # -- Additional PrometheusRule groups
-  additionalGroups: []
+# -- Number of replicas (pods) to launch.
+replicaCount: 1
 
 # -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
@@ -42,3 +27,71 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+# -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration.
+nodeSelector: {}
+
+# -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
+tolerations: []
+
+# -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
+affinity: {}
+
+# -- [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
+topologySpreadConstraints: []
+
+# -- Deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) configuration.
+strategy: {}
+  # rollingUpdate:
+  #   maxUnavailable: 1
+# type: RollingUpdate
+
+# -- Define the [count of deployment revisions](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) to be kept.
+# May be set to 0 in case of GitOps deployment approach.
+revisionHistoryLimit: 10
+
+podDisruptionBudget:
+  # -- Enable a [pod distruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to help dealing with [disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/).
+  # It is **highly recommended** for webhooks as disruptions can prevent launching new pods.
+  enabled: false
+
+  # -- (int/percentage) Number or percentage of pods that must remain available.
+  minAvailable:
+
+  # -- (int/percentage) Number or percentage of pods that can be unavailable.
+  maxUnavailable:
+
+# -- Specify a priority class name to set [pod priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority).
+priorityClassName: ""
+
+# -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
+# @default -- No requests or limits.
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+serviceMonitor:
+  # -- Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) serviceMonitor resource
+  enabled: false
+  # -- Scrape interval for serviceMonitor
+  interval: 15s
+
+prometheusRule:
+  # -- Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) prometheusRule resource
+  enabled: false
+  # -- Setup default alerts (works only if prometheusRule.enabled is set to true)
+  defaultGroupsEnabled: true
+  # -- Additional PrometheusRule groups
+  additionalGroups: []


### PR DESCRIPTION
These options help to place pods of the exporter to desirable nodes.
* Revision history
* Node selector
* Tolerations
* Topology spread constraints
* Affinity
* PDB

*Attention!* Replicas count and resources are now under the global values key.