### PR TITLE
Allow plain HTTP

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ func main() {
 	bindAddr := flag.String("bind-address", ":8080", "address:port to bind /metrics endpoint to")
 	namespaceLabels := flag.String("namespace-label", "", "namespace label for checks")
 	insecureSkipVerify := flag.Bool("skip-registry-cert-verification", false, "whether to skip registries' certificate verification")
-	defaultRegistry := flag.String("default-registry", "",
-		fmt.Sprintf("default registry to use in absence of a fully qualified image name, defaults to %q", name.DefaultRegistry))
+	plainHTTP := flag.Bool("allow-plain-http", false, "whether to fallback to HTTP scheme for registries that don't support HTTPS") // named after the ctr cli flag
+	defaultRegistry := flag.String("default-registry", "", fmt.Sprintf("default registry to use in absence of a fully qualified image name, defaults to %q", name.DefaultRegistry))
 
 	flag.Parse()
 
@@ -77,6 +77,7 @@ func main() {
 		stopCh,
 		kubeClient,
 		*insecureSkipVerify,
+		*plainHTTP,
 		regexes,
 		*defaultRegistry,
 		*namespaceLabels,

--- a/pkg/registry/checker_test.go
+++ b/pkg/registry/checker_test.go
@@ -16,13 +16,13 @@ func Test_parseImageName(t *testing.T) {
 		defaultRegistryName = "test-registry.io"
 	)
 
-	_, err := parseImageName(goodImageName, "")
+	_, err := parseImageName(goodImageName, "", false)
 	require.NoError(t, err)
 
-	_, err = parseImageName(badImageName, "")
+	_, err = parseImageName(badImageName, "", false)
 	require.Error(t, err)
 
-	ref, err := parseImageName(goodImageNameWithoutRegistry, defaultRegistryName)
+	ref, err := parseImageName(goodImageNameWithoutRegistry, defaultRegistryName, false)
 	require.NoError(t, err)
-	require.Equal(t, ref.Name(), path.Join(defaultRegistryName, goodImageNameWithoutRegistry))
+	require.Equal(t, path.Join(defaultRegistryName, goodImageNameWithoutRegistry), ref.Name())
 }


### PR DESCRIPTION
Some private registries and registries for testing purposes do not have TLS (and do not need to have). This commit adds a new `--allow-plain-http` flag named after the ctr cli flag that makes the export fall back for using the HTTP scheme if the HTTPS request is not possible.

Closes https://github.com/deckhouse/k8s-image-availability-exporter/issues/23