### PR TITLE
Add capath flag to provide custom CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,12 @@ spec:
 
 ```
 Usage of k8s-image-availability-exporter:
+  -allow-plain-http
+        whether to fallback to HTTP scheme for registries that don't support HTTPS
   -bind-address string
         address:port to bind /metrics endpoint to (default ":8080")
+  -capath value
+        path to a file that contains CA certificates in the PEM format
   -check-interval duration
         image re-check interval (default 1m0s)
   -default-registry string

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func NewPrometheusHook() *PrometheusHook {
@@ -24,11 +24,11 @@ type PrometheusHook struct {
 	counter *prometheus.CounterVec
 }
 
-func (h *PrometheusHook) Levels() []log.Level {
-	return log.AllLevels
+func (h *PrometheusHook) Levels() []logrus.Level {
+	return logrus.AllLevels
 }
 
-func (h *PrometheusHook) Fire(e *log.Entry) error {
+func (h *PrometheusHook) Fire(e *logrus.Entry) error {
 	h.counter.WithLabelValues(e.Level.String()).Inc()
 	return nil
 }

--- a/pkg/registry/indexers.go
+++ b/pkg/registry/indexers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flant/k8s-image-availability-exporter/pkg/store"
 	"github.com/google/go-containerregistry/pkg/authn"
 	kubeauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -201,7 +201,7 @@ func (ci ControllerIndexers) ExtractPullSecretRefs(obj interface{}) (ret []strin
 
 		saRaw, exists, err := ci.serviceAccountIndexer.GetByKey(fmt.Sprintf("%s/%s", cis.Namespace, serviceAccountName))
 		if err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 			return
 		}
 
@@ -284,7 +284,7 @@ func (ci ControllerIndexers) GetKeychainForImage(image string) authn.Keychain {
 
 	kc, err := kubeauth.NewFromPullSecrets(context.TODO(), dereferencedPullSecrets)
 	if err != nil {
-		log.Panic(err)
+		logrus.Panic(err)
 	}
 
 	return kc


### PR DESCRIPTION
This is required for private registries an air-gapped environments.

Closes https://github.com/deckhouse/k8s-image-availability-exporter/issues/45