### PR TITLE
Fallback to default keychain for registry auth

### DIFF
--- a/pkg/registry/checker.go
+++ b/pkg/registry/checker.go
@@ -323,6 +323,11 @@ func check(ref name.Reference, kc authn.Keychain, registryTransport *http.Transp
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
+	// Fallback to default keychain if image is not found in the provided one.
+	// This is a behavior that is close to what CRI does. Because, there is maybe an image pull secret, but with
+	// the wrong credentials. Yet, the image may be available with the default keychain.
+	kc = authn.NewMultiKeychain(kc, authn.DefaultKeychain)
+
 	_, imgErr = remote.Head(
 		ref,
 		remote.WithAuthFromKeychain(kc),


### PR DESCRIPTION
This is a behavior that is close to what CRI does. There may be an image pull secret but with the wrong credentials. Yet, the image may be available with the default keychain.

Closes https://github.com/deckhouse/k8s-image-availability-exporter/pull/63