### PR TITLE
Bump chart appVersion to 0.7.0

### DIFF
--- a/charts/k8s-image-availability-exporter/Chart.yaml
+++ b/charts/k8s-image-availability-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.6.1"
+appVersion: "0.7.0"
 description: Application for monitoring the cluster workloads image presence in a container registry.
 name: k8s-image-availability-exporter
-version: "0.10.1"
+version: "0.11.0"
 kubeVersion: ">=1.14.0-0"
 maintainers:
 - name: nabokihms

--- a/charts/k8s-image-availability-exporter/README.md
+++ b/charts/k8s-image-availability-exporter/README.md
@@ -1,6 +1,6 @@
 # k8s-image-availability-exporter
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Application for monitoring the cluster workloads image presence in a container registry.
 


### PR DESCRIPTION
https://github.com/deckhouse/k8s-image-availability-exporter/releases/tag/v0.7.0