### PR TITLE
Add handling of incorrect docker hub URLs

### DIFF
--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -76,7 +76,6 @@ func updateDockerRegistryAuths(dockerConfig map[string]interface{}) error {
 	return nil
 }
 
-
 func (p Provider) GetAuthKeychain(registry string) (authn.Keychain, error) {
 	dereferencedPullSecrets := p.pullSecretsGetter(registry)
 	correctedSecrets, err := p.correctDockerRegistry(dereferencedPullSecrets)

--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	kubeauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 )
@@ -24,73 +25,97 @@ func NewProvider(pullSecretsGetter func(image string) []corev1.Secret) *Provider
 }
 
 func (p Provider) correctDockerRegistry(secrets []corev1.Secret) ([]corev1.Secret, error) {
-    for i, secret := range secrets {
-        if secret.Type != corev1.SecretTypeDockerConfigJson {
-            continue
-        }
+	for i, secret := range secrets {
+		if secret.Type != corev1.SecretTypeDockerConfigJson && secret.Type != corev1.SecretTypeDockercfg {
+			continue
+		}
 
-        var dockerConfig map[string]json.RawMessage
-        var err error
+		var data []byte
+		var exists bool
+		if secret.Type == corev1.SecretTypeDockerConfigJson {
+			data, exists = secret.Data[corev1.DockerConfigJsonKey]
+		} else {
+			data, exists = secret.Data[corev1.DockerConfigKey]
+		}
+		if !exists {
+			continue
+		}
 
-        if data, exists := secret.Data[corev1.DockerConfigJsonKey]; exists {
-            err = json.Unmarshal(data, &dockerConfig)
-        } else if data, exists := secret.Data[corev1.DockerConfigKey]; exists {
-            // .dockercfg is in a different format, so we need to parse it differently
-            dockerConfig, err = parseDockercfg(data)
-        } else {
-            continue
-        }
+		dockerConfig, err := parseDockerConfig(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse docker config for secret %d: %w", i, err)
+		}
 
-        if err != nil {
-            return nil, fmt.Errorf("failed to parse docker config for secret %d: %w", i, err)
-        }
+		if err := updateDockerRegistryAuths(dockerConfig); err != nil {
+			return nil, fmt.Errorf("failed to update docker registry auths for secret %d: %w", i, err)
+		}
 
-        if err := updateDockerRegistryAuths(dockerConfig); err != nil {
-            return nil, fmt.Errorf("failed to update docker registry auths for secret %d: %w", i, err)
-        }
+		updatedData, err := json.Marshal(dockerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal updated docker config for secret %d: %w", i, err)
+		}
 
-        updatedData, err := json.Marshal(dockerConfig)
-        if err != nil {
-            return nil, fmt.Errorf("failed to marshal updated docker config for secret %d: %w", i, err)
-        }
-
-        secrets[i].Data[corev1.DockerConfigJsonKey] = updatedData
-    }
-    return secrets, nil
+		if secret.Type == corev1.SecretTypeDockerConfigJson {
+			secrets[i].Data[corev1.DockerConfigJsonKey] = updatedData
+		} else {
+			secrets[i].Data[corev1.DockerConfigKey] = updatedData
+		}
+	}
+	return secrets, nil
 }
 
-func parseDockercfg(data []byte) (map[string]json.RawMessage, error) {
-    var dockercfg struct {
-        Auths map[string]json.RawMessage `json:"auths"`
-    }
-    err := json.Unmarshal(data, &dockercfg)
-    if err != nil {
-        return nil, err
-    }
-    return dockercfg.Auths, nil
+// Example of incoming data for DockerConfigJson:
+// {
+//     "auths": {
+//         "https://index.docker.io/v1/": {"auth": "xxxx=="},
+//         "https://docker.io/v1/": {"auth": "xxxx=="}
+//     }
+// }
+// Example of outgoing data for DockerConfig:
+// {
+//      "https://index.docker.io/v1/": {"auth": "xxxx=="}
+// }
+
+func parseDockerConfig(data []byte) (map[string]json.RawMessage, error) {
+	var dockerConfig map[string]json.RawMessage
+
+	if err := json.Unmarshal(data, &dockerConfig); err != nil {
+		return nil, fmt.Errorf("unmarshalling docker config: %w", err)
+	}
+
+	return dockerConfig, nil
 }
 
 func updateDockerRegistryAuths(dockerConfig map[string]json.RawMessage) error {
-    auths, ok := dockerConfig["auths"]
-    if !ok {
-        return nil
-    }
+	if authsRaw, exists := dockerConfig["auths"]; exists {
+		var authsMap map[string]json.RawMessage
+		if err := json.Unmarshal(authsRaw, &authsMap); err != nil {
+			return fmt.Errorf("unmarshalling 'auths': %w", err)
+		}
 
-    var authsMap map[string]json.RawMessage
-    err := json.Unmarshal(auths, &authsMap)
-    if err != nil {
-        return err
-    }
+		for url, creds := range authsMap {
+			if strings.Contains(url, "docker.io") && url != "https://index.docker.io/v1/" {
+				authsMap["https://index.docker.io/v1/"] = creds
+				delete(authsMap, url)
+			}
+		}
 
-    for url, creds := range authsMap {
-        if strings.Contains(url, "docker.io") && url != "https://index.docker.io/v1/" {
-            authsMap["https://index.docker.io/v1/"] = creds
-            delete(authsMap, url)
-        }
-    }
+		updatedAuthsRaw, err := json.Marshal(authsMap)
+		if err != nil {
+			return fmt.Errorf("marshalling updated 'auths': %w", err)
+		}
+		dockerConfig["auths"] = updatedAuthsRaw
+	} else {
+		for url, creds := range dockerConfig {
+			if strings.Contains(url, "docker.io") && url != "https://index.docker.io/v1/" {
+				dockerConfig["https://index.docker.io/v1/"] = creds
+				delete(dockerConfig, url)
+				break
+			}
+		}
+	}
 
-    dockerConfig["auths"], err = json.Marshal(authsMap)
-    return err
+	return nil
 }
 
 func (p Provider) GetAuthKeychain(registry string) (authn.Keychain, error) {
@@ -99,12 +124,14 @@ func (p Provider) GetAuthKeychain(registry string) (authn.Keychain, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	kc, err := kubeauth.NewFromPullSecrets(context.TODO(), correctedSecrets)
 	if err != nil {
 		return nil, fmt.Errorf("error while processing keychain from secrets: %w", err)
 	}
 	return kc, nil
 }
+
 func (p Provider) GetName() string {
 	return p.name
 }

--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -24,56 +24,73 @@ func NewProvider(pullSecretsGetter func(image string) []corev1.Secret) *Provider
 }
 
 func (p Provider) correctDockerRegistry(secrets []corev1.Secret) ([]corev1.Secret, error) {
-	for i, secret := range secrets {
-		if secret.Type != corev1.SecretTypeDockerConfigJson {
-			continue
-		}
+    for i, secret := range secrets {
+        if secret.Type != corev1.SecretTypeDockerConfigJson {
+            continue
+        }
 
-		data, exists := secret.Data[corev1.DockerConfigJsonKey]
-		if !exists {
-			continue
-		}
+        var dockerConfig map[string]json.RawMessage
+        var err error
 
-		dockerConfig, err := parseDockerConfig(data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse docker config for secret %d: %w", i, err)
-		}
+        if data, exists := secret.Data[corev1.DockerConfigJsonKey]; exists {
+            err = json.Unmarshal(data, &dockerConfig)
+        } else if data, exists := secret.Data[corev1.DockerConfigKey]; exists {
+            // .dockercfg is in a different format, so we need to parse it differently
+            dockerConfig, err = parseDockercfg(data)
+        } else {
+            continue
+        }
 
-		if err := updateDockerRegistryAuths(dockerConfig); err != nil {
-			return nil, fmt.Errorf("failed to update docker registry auths for secret %d: %w", i, err)
-		}
+        if err != nil {
+            return nil, fmt.Errorf("failed to parse docker config for secret %d: %w", i, err)
+        }
 
-		updatedData, err := json.Marshal(dockerConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal updated docker config for secret %d: %w", i, err)
-		}
+        if err := updateDockerRegistryAuths(dockerConfig); err != nil {
+            return nil, fmt.Errorf("failed to update docker registry auths for secret %d: %w", i, err)
+        }
 
-		secrets[i].Data[corev1.DockerConfigJsonKey] = updatedData
-	}
-	return secrets, nil
+        updatedData, err := json.Marshal(dockerConfig)
+        if err != nil {
+            return nil, fmt.Errorf("failed to marshal updated docker config for secret %d: %w", i, err)
+        }
+
+        secrets[i].Data[corev1.DockerConfigJsonKey] = updatedData
+    }
+    return secrets, nil
 }
 
-func parseDockerConfig(data []byte) (map[string]interface{}, error) {
-	var dockerConfig map[string]interface{}
-	if err := json.Unmarshal(data, &dockerConfig); err != nil {
-		return nil, fmt.Errorf("unmarshalling docker config: %w", err)
-	}
-	return dockerConfig, nil
+func parseDockercfg(data []byte) (map[string]json.RawMessage, error) {
+    var dockercfg struct {
+        Auths map[string]json.RawMessage `json:"auths"`
+    }
+    err := json.Unmarshal(data, &dockercfg)
+    if err != nil {
+        return nil, err
+    }
+    return dockercfg.Auths, nil
 }
 
-func updateDockerRegistryAuths(dockerConfig map[string]interface{}) error {
-	auths, ok := dockerConfig["auths"].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("'auths' section is missing or invalid in docker config")
-	}
+func updateDockerRegistryAuths(dockerConfig map[string]json.RawMessage) error {
+    auths, ok := dockerConfig["auths"]
+    if !ok {
+        return nil
+    }
 
-	for url, creds := range auths {
-		if strings.Contains(url, "docker.io") && url != "https://index.docker.io/v1/" {
-			auths["https://index.docker.io/v1/"] = creds
-			delete(auths, url)
-		}
-	}
-	return nil
+    var authsMap map[string]json.RawMessage
+    err := json.Unmarshal(auths, &authsMap)
+    if err != nil {
+        return err
+    }
+
+    for url, creds := range authsMap {
+        if strings.Contains(url, "docker.io") && url != "https://index.docker.io/v1/" {
+            authsMap["https://index.docker.io/v1/"] = creds
+            delete(authsMap, url)
+        }
+    }
+
+    dockerConfig["auths"], err = json.Marshal(authsMap)
+    return err
 }
 
 func (p Provider) GetAuthKeychain(registry string) (authn.Keychain, error) {

--- a/pkg/providers/k8s/k8s.go
+++ b/pkg/providers/k8s/k8s.go
@@ -2,9 +2,11 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	kubeauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	corev1 "k8s.io/api/core/v1"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 )
@@ -21,9 +23,44 @@ func NewProvider(pullSecretsGetter func(image string) []corev1.Secret) *Provider
 	}
 }
 
+func (p Provider) correctDockerRegistry(secrets []corev1.Secret) ([]corev1.Secret, error) {
+	for i, secret := range secrets {
+		if secret.Type == corev1.SecretTypeDockerConfigJson {
+			data, exists := secret.Data[corev1.DockerConfigJsonKey]
+			if exists {
+				var dockerConfig map[string]interface{}
+				if err := json.Unmarshal(data, &dockerConfig); err == nil {
+					auths, ok := dockerConfig["auths"].(map[string]interface{})
+					if ok {
+						for url := range auths {
+							if strings.Contains(url, "docker.io") && url != "https://index.docker.io/v1/" {
+								auths["https://index.docker.io/v1/"] = auths[url]
+								delete(auths, url)
+							}
+						}
+						updatedData, err := json.Marshal(dockerConfig)
+						if err == nil {
+							secrets[i].Data[corev1.DockerConfigJsonKey] = updatedData
+						} else {
+							return nil, fmt.Errorf("failed to re-marshal docker config: %v", err)
+						}
+					}
+				} else {
+					return nil, fmt.Errorf("failed to unmarshal docker config: %v", err)
+				}
+			}
+		}
+	}
+	return secrets, nil
+}
+
 func (p Provider) GetAuthKeychain(registry string) (authn.Keychain, error) {
 	dereferencedPullSecrets := p.pullSecretsGetter(registry)
-	kc, err := kubeauth.NewFromPullSecrets(context.TODO(), dereferencedPullSecrets)
+	correctedSecrets, err := p.correctDockerRegistry(dereferencedPullSecrets)
+	if err != nil {
+		return nil, err
+	}
+	kc, err := kubeauth.NewFromPullSecrets(context.TODO(), correctedSecrets)
 	if err != nil {
 		return nil, fmt.Errorf("error while processing keychain from secrets: %w", err)
 	}


### PR DESCRIPTION
Because of incorrect registry url of docker hub in imagePullSecret we receiving alerts that images are unavailable and 401 UNAUTHORIZED in app logs.
Example of incorrect creds:
```
{
  "auths": {
    "docker.io": {
      "username": "login",
      "password": "password",
      "auth": "auth_chain"
    }
  }
}
``` 

Correct way:

```
{
  "auths": {
    "https://index.docker.io/v1/": {
      "username": "login",
      "password": "pass",
      "auth": "chain"
    }
  }
}
```