### PR TITLE
Add optional pending duration field to PrometheusRules

### DIFF
--- a/charts/k8s-image-availability-exporter/README.md
+++ b/charts/k8s-image-availability-exporter/README.md
@@ -60,9 +60,9 @@ This chart bootstraps a [k8s-image-availability-exporter](https://github.com/fla
 | serviceMonitor.relabelings | list | `[]` | Relabel configs to apply to samples before ingestion. # [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |
 | prometheusRule.enabled | bool | `false` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) prometheusRule resource |
 | prometheusRule.defaultGroupsEnabled | bool | `true` | Setup default alerts (works only if prometheusRule.enabled is set to true) |
-| prometheusRule.additionalGroups | list | `[]` | Additional PrometheusRule groups |
-
+| prometheusRule.for | string | `""` | Optional duration for which the condition must be true before firing. If not set, alerts fire immediately. |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+| prometheusRule.additionalGroups | list | `[]` | Additional PrometheusRule groups |
 
 ```bash
 helm install my-release k8s-image-availability-exporter --set k8sImageAvailabilityExporter.replicas=2

--- a/charts/k8s-image-availability-exporter/templates/prometheus-rule.yaml
+++ b/charts/k8s-image-availability-exporter/templates/prometheus-rule.yaml
@@ -13,6 +13,9 @@ spec:
         max by (namespace, name, container, image) (
           k8s_image_availability_exporter_available{kind="deployment"} == 0
         )
+      {{- if .Values.prometheusRule.for }}
+      for: {{ .Values.prometheusRule.for }}
+      {{- end }}
       annotations:
         message: >
           Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
@@ -26,6 +29,9 @@ spec:
         max by (namespace, name, container, image) (
           k8s_image_availability_exporter_available{kind="statefulset"} == 0
         )
+      {{- if .Values.prometheusRule.for }}
+      for: {{ .Values.prometheusRule.for }}
+      {{- end }}
       annotations:
         message: >
           Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
@@ -39,6 +45,9 @@ spec:
         max by (namespace, name, container, image) (
           k8s_image_availability_exporter_available{kind="daemonset"} == 0
         )
+      {{- if .Values.prometheusRule.for }}
+      for: {{ .Values.prometheusRule.for }}
+      {{- end }}
       annotations:
         message: >
           Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
@@ -52,6 +61,9 @@ spec:
         max by (namespace, name, container, image) (
           k8s_image_availability_exporter_available{kind="cronjob"} == 0
         )
+      {{- if .Values.prometheusRule.for }}
+      for: {{ .Values.prometheusRule.for }}
+      {{- end }}
       annotations:
         message: >
           Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}

--- a/charts/k8s-image-availability-exporter/values.yaml
+++ b/charts/k8s-image-availability-exporter/values.yaml
@@ -164,5 +164,7 @@ prometheusRule:
   enabled: false
   # -- Setup default alerts (works only if prometheusRule.enabled is set to true)
   defaultGroupsEnabled: true
+  # -- Optional duration for which the condition must be true before firing. If not set, alerts fire immediately.
+  for: ""
   # -- Additional PrometheusRule groups
   additionalGroups: []


### PR DESCRIPTION
The default `PrometheusRule` alerts fire immediately when a condition is met, causing noisy alerts on transient errors like brief registry timeouts or network blips.

This adds an optional `prometheusRule.for` value that sets the for duration on all default alert rules. When not set, behavior is unchanged.

Usage:
```
# values.yaml
prometheusRule:
  enabled: true
  for: "5m"
```

produces rules like this
```
- alert: DeploymentImageUnavailable
  expr: |
    max by (namespace, name, container, image) (
      k8s_image_availability_exporter_available{kind="deployment"} == 0
    )
  for: 5m
  annotations:
    message: >
      Image {{ $labels.image }} from container {{ $labels.container }}
      in deployment {{ $labels.name }}
      from namespace {{ $labels.namespace }}
      is not available in docker registry.
  labels:
    severity: critical
```

Closes https://github.com/deckhouse/k8s-image-availability-exporter/issues/407

