### PR TITLE
Fix using mirrors for defaultRegistry

### DIFF
--- a/pkg/registry/checker.go
+++ b/pkg/registry/checker.go
@@ -6,6 +6,12 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/flant/k8s-image-availability-exporter/pkg/providers"
 	"github.com/flant/k8s-image-availability-exporter/pkg/providers/amazon"
 	"github.com/flant/k8s-image-availability-exporter/pkg/providers/k8s"
@@ -14,11 +20,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"net/http"
-	"os"
-	"regexp"
-	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -334,7 +335,7 @@ func (rc *Checker) checkImageAvailability(log *logrus.Entry, imageName string, k
 	}
 
 	if len(rc.config.mirrorsMap) > 0 {
-		imageName = getImageWithMirror(ref.String(), rc.config.mirrorsMap)
+		imageName = getImageWithMirror(ref.Name(), rc.config.mirrorsMap)
 		ref, err = parseImageName(imageName, rc.config.defaultRegistry, rc.config.plainHTTP)
 		if err != nil {
 			return checkImageNameParseErr(log, err)

--- a/pkg/registry/checker.go
+++ b/pkg/registry/checker.go
@@ -335,7 +335,7 @@ func (rc *Checker) checkImageAvailability(log *logrus.Entry, imageName string, k
 
 	if len(rc.config.mirrorsMap) > 0 {
 		imageName = getImageWithMirror(ref.String(), rc.config.mirrorsMap)
-		ref, err := parseImageName(imageName, rc.config.defaultRegistry, rc.config.plainHTTP)
+		ref, err = parseImageName(imageName, rc.config.defaultRegistry, rc.config.plainHTTP)
 		if err != nil {
 			return checkImageNameParseErr(log, err)
 		}

--- a/pkg/registry/checker.go
+++ b/pkg/registry/checker.go
@@ -328,13 +328,17 @@ func getImageWithMirror(originalImage string, mirrors map[string]string) string 
 }
 
 func (rc *Checker) checkImageAvailability(log *logrus.Entry, imageName string, kc authn.Keychain) (availMode store.AvailabilityMode) {
-	if len(rc.config.mirrorsMap) > 0 {
-		imageName = getImageWithMirror(imageName, rc.config.mirrorsMap)
-	}
-
 	ref, err := parseImageName(imageName, rc.config.defaultRegistry, rc.config.plainHTTP)
 	if err != nil {
 		return checkImageNameParseErr(log, err)
+	}
+
+	if len(rc.config.mirrorsMap) > 0 {
+		imageName = getImageWithMirror(ref.String(), rc.config.mirrorsMap)
+		ref, err := parseImageName(imageName, rc.config.defaultRegistry, rc.config.plainHTTP)
+		if err != nil {
+			return checkImageNameParseErr(log, err)
+		}
 	}
 
 	imgErr := wait.ExponentialBackoff(wait.Backoff{

--- a/pkg/registry/checker_test.go
+++ b/pkg/registry/checker_test.go
@@ -1,9 +1,20 @@
 package registry
 
 import (
+	"fmt"
+	"net/http"
 	"path"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/flant/k8s-image-availability-exporter/pkg/store"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,4 +36,99 @@ func Test_parseImageName(t *testing.T) {
 	ref, err := parseImageName(goodImageNameWithoutRegistry, defaultRegistryName, false)
 	require.NoError(t, err)
 	require.Equal(t, path.Join(defaultRegistryName, goodImageNameWithoutRegistry), ref.Name())
+}
+
+var log = logrus.NewEntry(logrus.StandardLogger())
+var kcMock authn.Keychain = nil
+
+// Return statusCode from first 3 chars of http host.
+// For example: request to 404.docker.io returns statusCode 404 (NotFound)
+type MockRegistryTransportStatuses struct {
+}
+
+func (m *MockRegistryTransportStatuses) RoundTrip(req *http.Request) (*http.Response, error) {
+	statusCode, err := strconv.Atoi(req.Host[:3])
+	if err == nil {
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       http.NoBody,
+			Header: http.Header{
+				"Content-Type":          {"application/vnd.docker.distribution.manifest.v1+json"},
+				"Docker-Content-Digest": {"sha256:33e0bbc7ca9ecf108140af6288c7c9d1ecc77548cbfd3952fd8466a75edefe57"},
+			},
+		}, nil
+	} else {
+		return &http.Response{StatusCode: http.StatusRequestTimeout, Body: http.NoBody}, nil
+	}
+}
+
+func Test_checkImageAvailability_statuses(t *testing.T) {
+	rc := &Checker{
+		config: registryCheckerConfig{
+			defaultRegistry: "index.docker.io",
+			mirrorsMap:      nil,
+			plainHTTP:       false,
+		},
+		registryTransport: &MockRegistryTransportStatuses{},
+	}
+
+	mode := rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusOK), kcMock)
+	assert.Equal(t, store.Available, mode)
+
+	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusNotFound), kcMock)
+	assert.Equal(t, store.Absent, mode)
+
+	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusUnauthorized), kcMock)
+	assert.Equal(t, store.AuthnFailure, mode)
+
+	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusForbidden), kcMock)
+	assert.Equal(t, store.AuthzFailure, mode)
+
+	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusRequestTimeout), kcMock)
+	assert.Equal(t, store.UnknownError, mode)
+}
+
+// It is assumed that defaultRegistry is unavailable, but mirrors are working.
+type MockMirrorRegistryTransport struct {
+}
+
+func (m *MockMirrorRegistryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(req.Host, "mirror") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+			Header: http.Header{
+				"Content-Type":          {"application/vnd.docker.distribution.manifest.v1+json"},
+				"Docker-Content-Digest": {"sha256:33e0bbc7ca9ecf108140af6288c7c9d1ecc77548cbfd3952fd8466a75edefe57"},
+			},
+		}, nil
+	} else {
+		return &http.Response{
+			StatusCode: http.StatusRequestTimeout,
+			Body:       http.NoBody,
+		}, nil
+	}
+}
+
+func Test_checkImageAvailability_mirrorForDefaultRegistry(t *testing.T) {
+	rc := &Checker{
+		config: registryCheckerConfig{
+			defaultRegistry: "index.docker.io",
+			mirrorsMap:      map[string]string{"index.docker.io": "mirror.local"},
+			plainHTTP:       false,
+		},
+		registryTransport: &MockMirrorRegistryTransport{},
+	}
+
+	mode := rc.checkImageAvailability(log, "test:test", kcMock)
+	assert.Equal(t, store.Available, mode)
+
+	mode = rc.checkImageAvailability(log, "index.docker.io/test:test", kcMock)
+	assert.Equal(t, store.Available, mode)
+
+	mode = rc.checkImageAvailability(log, "docker.io/test:test", kcMock)
+	assert.Equal(t, store.Available, mode)
+
+	mode = rc.checkImageAvailability(log, "local/test:test", kcMock)
+	assert.Equal(t, store.Available, mode)
 }

--- a/pkg/registry/checker_test.go
+++ b/pkg/registry/checker_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"strconv"
@@ -38,9 +39,6 @@ func Test_parseImageName(t *testing.T) {
 	require.Equal(t, path.Join(defaultRegistryName, goodImageNameWithoutRegistry), ref.Name())
 }
 
-var log = logrus.NewEntry(logrus.StandardLogger())
-var kcMock authn.Keychain = nil
-
 // Return statusCode from first 3 chars of http host.
 // For example: request to 404.docker.io returns statusCode 404 (NotFound)
 type MockRegistryTransportStatuses struct {
@@ -53,7 +51,7 @@ func (m *MockRegistryTransportStatuses) RoundTrip(req *http.Request) (*http.Resp
 			StatusCode: statusCode,
 			Body:       http.NoBody,
 			Header: http.Header{
-				"Content-Type":          {"application/vnd.docker.distribution.manifest.v1+json"},
+				"Content-Type":          {"application/vnd.docker.distribution.manifest.v2+json"},
 				"Docker-Content-Digest": {"sha256:33e0bbc7ca9ecf108140af6288c7c9d1ecc77548cbfd3952fd8466a75edefe57"},
 			},
 		}, nil
@@ -63,6 +61,12 @@ func (m *MockRegistryTransportStatuses) RoundTrip(req *http.Request) (*http.Resp
 }
 
 func Test_checkImageAvailability_statuses(t *testing.T) {
+	var kcMock authn.Keychain = nil
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	log := logrus.NewEntry(logger)
+
 	rc := &Checker{
 		config: registryCheckerConfig{
 			defaultRegistry: "index.docker.io",
@@ -73,6 +77,12 @@ func Test_checkImageAvailability_statuses(t *testing.T) {
 	}
 
 	mode := rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusOK), kcMock)
+	assert.Equal(t, store.Available, mode)
+
+	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/library/test:test", http.StatusOK), kcMock)
+	assert.Equal(t, store.Available, mode)
+
+	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test@sha256:33e0bbc7ca9ecf108140af6288c7c9d1ecc77548cbfd3952fd8466a75edefe57", http.StatusOK), kcMock)
 	assert.Equal(t, store.Available, mode)
 
 	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusNotFound), kcMock)
@@ -86,6 +96,12 @@ func Test_checkImageAvailability_statuses(t *testing.T) {
 
 	mode = rc.checkImageAvailability(log, fmt.Sprintf("%d.local/test:test", http.StatusRequestTimeout), kcMock)
 	assert.Equal(t, store.UnknownError, mode)
+
+	mode = rc.checkImageAvailability(log, "te*^#@@st", kcMock)
+	assert.Equal(t, store.BadImageName, mode)
+
+	mode = rc.checkImageAvailability(log, "test@sha256:33e0bbc7ca9e", kcMock)
+	assert.Equal(t, store.BadImageName, mode)
 }
 
 // It is assumed that defaultRegistry is unavailable, but mirrors are working.
@@ -98,7 +114,7 @@ func (m *MockMirrorRegistryTransport) RoundTrip(req *http.Request) (*http.Respon
 			StatusCode: http.StatusOK,
 			Body:       http.NoBody,
 			Header: http.Header{
-				"Content-Type":          {"application/vnd.docker.distribution.manifest.v1+json"},
+				"Content-Type":          {"application/vnd.docker.distribution.manifest.v2+json"},
 				"Docker-Content-Digest": {"sha256:33e0bbc7ca9ecf108140af6288c7c9d1ecc77548cbfd3952fd8466a75edefe57"},
 			},
 		}, nil
@@ -111,24 +127,45 @@ func (m *MockMirrorRegistryTransport) RoundTrip(req *http.Request) (*http.Respon
 }
 
 func Test_checkImageAvailability_mirrorForDefaultRegistry(t *testing.T) {
+	var kcMock authn.Keychain = nil
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	log := logrus.NewEntry(logger)
+
 	rc := &Checker{
 		config: registryCheckerConfig{
 			defaultRegistry: "index.docker.io",
-			mirrorsMap:      map[string]string{"index.docker.io": "mirror.local"},
-			plainHTTP:       false,
+			mirrorsMap: map[string]string{
+				"index.docker.io": "mirror.local",
+				"badhost.io":      "te*^#@@st.io",
+			},
+			plainHTTP: false,
 		},
 		registryTransport: &MockMirrorRegistryTransport{},
 	}
 
 	mode := rc.checkImageAvailability(log, "test:test", kcMock)
-	assert.Equal(t, store.Available, mode)
+	assert.Equal(t, store.Available, mode) // Via mirror
+
+	mode = rc.checkImageAvailability(log, "library/test:test", kcMock)
+	assert.Equal(t, store.Available, mode) // Via mirror
+
+	mode = rc.checkImageAvailability(log, "test@sha256:33e0bbc7ca9ecf108140af6288c7c9d1ecc77548cbfd3952fd8466a75edefe57", kcMock)
+	assert.Equal(t, store.Available, mode) // Via mirror
 
 	mode = rc.checkImageAvailability(log, "index.docker.io/test:test", kcMock)
-	assert.Equal(t, store.Available, mode)
+	assert.Equal(t, store.Available, mode) // Via mirror
 
-	mode = rc.checkImageAvailability(log, "docker.io/test:test", kcMock)
-	assert.Equal(t, store.Available, mode)
+	mode = rc.checkImageAvailability(log, "local.io/test:test", kcMock)
+	assert.Equal(t, store.UnknownError, mode) // Not via mirror
 
-	mode = rc.checkImageAvailability(log, "local/test:test", kcMock)
-	assert.Equal(t, store.Available, mode)
+	mode = rc.checkImageAvailability(log, "local.io/library/test:test", kcMock)
+	assert.Equal(t, store.UnknownError, mode) // Not via mirror
+
+	mode = rc.checkImageAvailability(log, "te*^#@@st", kcMock)
+	assert.Equal(t, store.BadImageName, mode) // Bad image name
+
+	mode = rc.checkImageAvailability(log, "badhost.io/test:test", kcMock)
+	assert.Equal(t, store.BadImageName, mode) // Bad host name in mirrorsMap
 }


### PR DESCRIPTION
Fixes a bug: if a mirror is configured for defaultRegistry, then the check does not go through this mirror, but goes directly.

For example:
I have configured mirror
```
        - original: docker.io
          mirror: registry.local:5555/docker
```
And all the images that assume they using defaultRegistry generate errors like this:
```
level=error msg="Get \"https://index.docker.io/v2/\": context deadline exceeded" availability_mode=unknown_error image_name="lersamr/full-r:3.65.3"
```