### PR TITLE
Enabling Multi Platform Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,13 @@ on:
     - v*
     branches:
     - main
-    - multi-platform-build
-  workflow_dispatch: # Allows you to click a "Run workflow" button
   pull_request:
     branches:
     - main
 
-# env:
-#   REGISTRY: registry-write.deckhouse.io
-#   IMAGE_NAME: k8s-image-availability-exporter/k8s-image-availability-exporter
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: pachecoc/k8s-image-availability-exporter
+  REGISTRY: registry-write.deckhouse.io
+  IMAGE_NAME: k8s-image-availability-exporter/k8s-image-availability-exporter
 
 jobs:
   test:
@@ -78,10 +73,8 @@ jobs:
         uses: docker/login-action@v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
-          # username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
-          # password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     - v*
     branches:
     - main
+    - multi-platform-build
   workflow_dispatch: # Allows you to click a "Run workflow" button
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,17 @@ on:
     - v*
     branches:
     - main
+  workflow_dispatch: # Allows you to click a "Run workflow" button
   pull_request:
     branches:
     - main
 
+# env:
+#   REGISTRY: registry-write.deckhouse.io
+#   IMAGE_NAME: k8s-image-availability-exporter/k8s-image-availability-exporter
 env:
-  REGISTRY: registry-write.deckhouse.io
-  IMAGE_NAME: k8s-image-availability-exporter/k8s-image-availability-exporter
+  REGISTRY: docker.io
+  IMAGE_NAME: pachecoc/k8s-image-availability-exporter
 
 jobs:
   test:
@@ -63,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -70,8 +77,10 @@ jobs:
         uses: docker/login-action@v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          # username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          # password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -86,6 +95,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.18.0
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.25.8-alpine as build
+FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine as build
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/app
 ADD . /go/src/app
@@ -6,7 +9,7 @@ ADD . /go/src/app
 RUN go get -d -v ./...
 
 ARG TAG
-RUN CGO_ENABLED=0 go build -a \
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a \
     -ldflags "-s -w -extldflags '-static' -X github.com/flant/k8s-image-availability-exporter/pkg/version.Version=${TAG}" \
     -o /go/bin/k8s-image-availability-exporter main.go
 


### PR DESCRIPTION
## WHAT

This PR enables multi-platform container image builds for both amd64 and arm64 architectures. This allows the exporter to run natively on ARM-based environments like AWS Graviton without `exec format error` issues.

## HOW

I have added the minimal possible changes to support this:

Dockerfile: Added TARGETOS and TARGETARCH arguments to leverage Go's native cross-compilation (avoiding the need for QEMU emulation).

GitHub Actions: Initialized docker/setup-buildx-action and updated the build step to target both platforms.

## TESTS

Verified on a personal fork. The build successfully produces a manifest list containing both architectures, and the image was tested on an ARM64 cluster.